### PR TITLE
app.xql – Verlinkung von about.html relativ zu app-root

### DIFF
--- a/modules/app.xql
+++ b/modules/app.xql
@@ -67,7 +67,7 @@ declare function app:menu($node as node(), $model as map(*)){
                        <li><a href="{$helpers:app-root}/recherche/bibliographie">Bibliographie</a></li>
                     </ul>
                 </li>
-                <li>{if ($resource = "about.html") then attribute class {"active"} else ()}<a href="about">About</a></li>
+                <li>{if ($resource = "about.html") then attribute class {"active"} else ()}<a href="{$helpers:app-root}/about">About</a></li>
              </ul>
         </nav>
 };


### PR DESCRIPTION
`about.html` wurde jeweils relativ zum aktuellen Kontext verlinkt, z.B. als `recherche/about.html` oder `texte/about.html`. Durch die Verlinkung `{$helpers:app-root}/about` sollte der korrekte Kontext berücksichtigt werden.